### PR TITLE
Bump toolkit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.0",
   "dependencies": {
-    "@cosmicds/vue-toolkit": "^0.1.3",
+    "@cosmicds/vue-toolkit": "^0.1.4",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/vue-fontawesome": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,10 +203,10 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@cosmicds/vue-toolkit@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.1.3.tgz#c29b8c42bb82cd274a7468fba433c6312ef167a6"
-  integrity sha512-D+z2l7x1JqD2RLFgf/pkA3DitIN4/7duGXfsBuAEFM9Kq52cw3Irso57Cw5ud3x3zkWGb0PHN3/jYk0GIVapYw==
+"@cosmicds/vue-toolkit@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.1.4.tgz#13ab7585db8c4ac3e17b26b8c2e0900c816d1f99"
+  integrity sha512-3D6zX1+QJsmf/vHM/LivKjzOtmrxkhXa5QSZHqMc0iKZwmHLMcLIIBP7Un6zotBYw1zbHuev0f7PuR4hW9703w==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.1"
     "@fortawesome/free-solid-svg-icons" "^6.5.1"


### PR DESCRIPTION
This PR bumps the version of the toolkit used to `0.1.4` so that we can use the NASA Grantee logo.